### PR TITLE
Fix import path for bitcask

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -49,6 +49,6 @@ protoc --go_out=plugins=grpc:src/ont_rpc -I protobuf/minknow/rpc protobuf/minkno
 
 ## Database
 
-Sample records are stored via [bitcask db](https://pkg.go.dev/github.com/prologic/bitcask), which is currently hardcoded to live in `/tmp/db`.
+Sample records are stored via [bitcask db](https://pkg.go.dev/git.mills.io/prologic/bitcask), which is currently hardcoded to live in `/tmp/db`.
 
 Sample records are stored in a keyvalue store, where the label is the key and the sample protobuf message is the value.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/prologic/bitcask v0.3.10
+	git.mills.io/prologic/bitcask v0.3.10
 	github.com/spf13/viper v1.7.1
 	github.com/will-rowe/archer v0.1.1
 	github.com/zserge/lorca v0.1.9

--- a/go.sum
+++ b/go.sum
@@ -315,8 +315,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
-github.com/prologic/bitcask v0.3.10 h1:HXygU8zCvW5gLpZ8aQECPk5iV/YQ3hcqdg/zVeES6s0=
-github.com/prologic/bitcask v0.3.10/go.mod h1:8RKJdbHLE7HFGLYSGu9slnYXSV7DMIucwVkaIYOk9GY=
+git.mills.io/prologic/bitcask v0.3.10 h1:HXygU8zCvW5gLpZ8aQECPk5iV/YQ3hcqdg/zVeES6s0=
+git.mills.io/prologic/bitcask v0.3.10/go.mod h1:8RKJdbHLE7HFGLYSGu9slnYXSV7DMIucwVkaIYOk9GY=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=

--- a/src/storage/storage.go
+++ b/src/storage/storage.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
-	"github.com/prologic/bitcask"
+	"git.mills.io/prologic/bitcask"
 
 	"github.com/will-rowe/herald/src/records"
 )


### PR DESCRIPTION
Project has moved to [git.mills.io/prologic/bitcask](https://git.mills.io/prologic/bitcask).

For details on why see: https://github.com/prologic

Thank you! 🙇